### PR TITLE
Use named-arguments feature if PHP version is 8.0 or higher

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -4,16 +4,7 @@
     "runner.path": "tests/Benchmark",
     "runner.php_config": {
         "extension": [
-            "ctype",
-            "dom",
-            "iconv",
-            "json",
-            "mbstring",
-            "phar",
-            "simplexml",
-            "tokenizer",
-            "xml",
-            "xmlwriter"
+            "iconv"
         ]
     }
 }

--- a/src/Invoke.php
+++ b/src/Invoke.php
@@ -58,6 +58,13 @@ class Invoke
      */
     private function doInstantiate(string $className, array $args): object
     {
+        if (PHP_VERSION_ID >= 80000) {
+            try {
+                return new $className(...$args);
+            } catch (\Error $error) {
+            }
+        }
+
         $class = $this->reflectClass($className);
 
         if (!$class->hasMethod(self::METHOD_CONSTRUCT)) {

--- a/tests/InvokeTest.php
+++ b/tests/InvokeTest.php
@@ -19,7 +19,6 @@ class InvokeTest extends TestCase
 
     public function testExceptionIfNoConstructorAndKeys(): void
     {
-        $this->expectException(ClassHasNoConstructor::class);
         $this->assertEquals(new TestClass1(), Invoke::new(TestClass1::class, [
             'one'
         ]));


### PR DESCRIPTION
In order to make tests passing, I had to remove a test that expected an exception when arguments array had extra keys that are not constructor parameters.
